### PR TITLE
Fix: type declarations are not exported

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "linq-functional",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "linq-functional",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "license": "ISC",
       "devDependencies": {
         "@vitest/coverage-c8": "^0.33.0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,18 @@
 {
   "name": "linq-functional",
   "type": "module",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A functional adaptation of C#'s LINQ, for building type safe, declarative queries.",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "import": {
+        "default": "./dist/index.js",
+        "types": "./dist/index.d.ts"
+      },
+      "require": {
+        "default": "./dist/index.cjs",
+        "types": "./dist/index.d.cts"
+      }
     }
   },
   "types": "./dist/index.d.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -23,9 +23,15 @@ export default [
     input: 'src/index.ts',
     external: id => /node_modules/.test(id),
     plugins: [dts()],
-    output: {
-      file: 'dist/index.d.ts',
-      format: 'es',
-    },
+    output: [
+      {
+        file: 'dist/index.d.ts',
+        format: 'es',
+      },
+      {
+        file: 'dist/index.d.cts',
+        format: 'cjs',
+      },
+    ],
   },
 ]


### PR DESCRIPTION
 - Add the creation of index.d.cts to the compilation step.
 - Add typings to the require section of exports.
 - Upgrade package version

Closes #6